### PR TITLE
fix pathfinding bugs

### DIFF
--- a/MouseMoveMode/PathFindingHelper.cs
+++ b/MouseMoveMode/PathFindingHelper.cs
@@ -380,6 +380,10 @@ namespace MouseMoveMode
                     for (int j = -1; j <= 1; j += 1)
                     {
                         Vector2 neighbor = new Vector2(current.X + i, current.Y + j);
+
+                        if (visited.Contains(neighbor))
+                            continue;
+
                         if (isValidMovement(current, neighbor))
                         {
                             // Pass all checked, this tile could be consider to be use

--- a/MouseMoveMode/PathFindingHelper.cs
+++ b/MouseMoveMode/PathFindingHelper.cs
@@ -355,6 +355,12 @@ namespace MouseMoveMode
             {
                 limit -= 1;
                 var current = pq.Dequeue();
+
+                if (visited.Contains(current))
+                    continue;
+                visited.Add(current);
+                this.visitedNodes.Add(new DrawableNode(Util.toBoxPosition(current)));
+
                 if (debugVerbose)
                 {
                     ModEntry.getMonitor().Log(String.Format("[Step {2}] Current {3} or in tile {0} = {1} fScore {4}", current, gScore[current], 100 - limit, addPadding(current), fScore[current]), LogLevel.Info);
@@ -374,10 +380,6 @@ namespace MouseMoveMode
                     for (int j = -1; j <= 1; j += 1)
                     {
                         Vector2 neighbor = new Vector2(current.X + i, current.Y + j);
-                        if (visited.Contains(neighbor))
-                        {
-                            continue;
-                        }
                         if (isValidMovement(current, neighbor))
                         {
                             // Pass all checked, this tile could be consider to be use
@@ -387,8 +389,6 @@ namespace MouseMoveMode
 
                 foreach (var neighbor in neighborList)
                 {
-                    visited.Add(neighbor);
-                    this.visitedNodes.Add(new DrawableNode(Util.toBoxPosition(neighbor)));
 
                     var temp = gScore[current] + calculateGScore(Util.toPosition(current), Util.toPosition(neighbor));
                     if (gScore.ContainsKey(neighbor))

--- a/MouseMoveMode/Util.cs
+++ b/MouseMoveMode/Util.cs
@@ -169,6 +169,20 @@ namespace MouseMoveMode
                 }
             }
 
+            foreach (StardewValley.TerrainFeatures.ResourceClump resourceClump in gl.resourceClumps)
+            {
+                if (!resourceClump.isPassable() &&
+                    resourceClump.getBoundingBox().Contains((int)tile.X * 64 + 32, (int)tile.Y * 64 + 32))
+                {
+                    if (Util.debugPassableVebose)
+                        ModEntry.getMonitor().Log("Found unpassable(?) resource clump " + resourceClump + " at " + tile, LogLevel.Info);
+                    cacheCantPassable.Add(tile);
+                    if (Util.debugPassable)
+                        nonPassableNodes.Add(new DrawableNode(Util.toBoxPosition(tile)));
+                    return false;
+                }
+            }
+
             if (gl.Objects.ContainsKey(tile))
             {
                 var item = gl.Objects[tile];


### PR DESCRIPTION
1) boulders/stumps/logs were treated as passable, but the player cannot walk through them.
2) overly-aggressive caching caused the A* algorithm to fail to consider routes that sometimes end up producing shorter paths.